### PR TITLE
Add support for spaces in directory names

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ async function init() {
 
 	updateStatus('Retrieving directory info…');
 
-	const files = await listContent.viaTreesApi(`${repo}#${ref}`, dir, localStorage.token, ref);
+	const files = await listContent.viaTreesApi(`${repo}#${ref}`, decodeURIComponent(dir), localStorage.token, ref);
 
 	updateStatus(`Downloading (0/${files.length}) files…`, '\n• ' + files.join('\n• '));
 


### PR DESCRIPTION
[`list-github-dir-content`](https://github.com/fregante/list-github-dir-content) requires the actual directory path while the one used in this app comes from the `url` GET parameter and is therefore URL-encoded.

This PR decodes the directory path before passing it along to `listContent.viaTreesApi()` and resolves #11.