### PR TITLE
Fix `save-file` usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,7 @@ async function init() {
 		type: 'blob'
 	});
 
-	await new Promise(resolve =>
-		saveFile(zipBlob, `${repo} ${ref} ${dir}.zip`.replace(/\//, '-'), resolve)
-	);
+	await saveFile(zipBlob, `${repo} ${ref} ${dir}.zip`.replace(/\//, '-'));
 	updateStatus(`Downloaded ${downloaded} files! Done!`);
 }
 


### PR DESCRIPTION
The [`save-file`](https://www.npmjs.com/package/save-file) dependency was updated in de9b2e7. It no longer uses Node.js-style callbacks but Promises for asynchronous actions.

This PR adjusts usage of `save-file` in source code accordingly.