### PR TITLE
Add support for downloading folders from private repos

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ async function init() {
 	try {
 		const query = new URLSearchParams(location.search);
 		const parsedUrl = new URL(query.get('url'));
-		[, user, repo, ref, dir] = repoDirRegex.exec(parsedUrl.pathname);
+		[, user, repo, ref, dir] = urlParserRegex.exec(parsedUrl.pathname);
 
 		console.log('Source:', {user, repo, ref, dir});
 	} catch {

--- a/index.js
+++ b/index.js
@@ -148,8 +148,8 @@ async function init() {
 		}
 
 		const {content} = await response.json();
-
-		return (await fetch(`data:application/octet-stream;base64,${content}`)).blob();
+		const decoder = await fetch(`data:application/octet-stream;base64,${content}`);
+		return decoder.blob();
 	};
 
 	let downloaded = 0;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import saveFile from 'save-file';
 import listContent from 'list-github-dir-content';
 
 // Matches '/<re/po>/tree/<ref>/<dir>'
-const repoDirRegex = /^[/](.+)[/](.+)[/]tree[/]([^/]+)[/](.*)/;
+const urlParserRegex = /^[/]([^/]+)[/]([^/]+)[/]tree[/]([^/]+)[/](.*)/;
 
 function updateStatus(status, ...extra) {
 	const el = document.querySelector('.status');

--- a/index.js
+++ b/index.js
@@ -82,16 +82,16 @@ async function init() {
 	await waitForToken();
 
 	let user;
-	let repo;
+	let repository;
 	let ref;
 	let dir;
 
 	try {
 		const query = new URLSearchParams(location.search);
 		const parsedUrl = new URL(query.get('url'));
-		[, user, repo, ref, dir] = urlParserRegex.exec(parsedUrl.pathname);
+		[, user, repository, ref, dir] = urlParserRegex.exec(parsedUrl.pathname);
 
-		console.log('Source:', {user, repo, ref, dir});
+		console.log('Source:', {user, repository, ref, dir});
 	} catch {
 		return updateStatus();
 	}
@@ -103,11 +103,11 @@ async function init() {
 
 	updateStatus('Retrieving directory info…');
 
-	const {private: repoIsPrivate} = await fetchRepoInfo(`${user}/${repo}`);
+	const {private: repoIsPrivate} = await fetchRepoInfo(`${user}/${repository}`);
 
 	const files = await listContent.viaTreesApi({
 		user,
-		repository: repo,
+		repository,
 		ref,
 		directory: decodeURIComponent(dir),
 		token: localStorage.token,
@@ -124,7 +124,7 @@ async function init() {
 	const controller = new AbortController();
 
 	const fetchPublicFile = async file => {
-		const response = await fetch(`https://raw.githubusercontent.com/${user}/${repo}/${ref}/${file.path}`, {
+		const response = await fetch(`https://raw.githubusercontent.com/${user}/${repository}/${ref}/${file.path}`, {
 			signal: controller.signal
 		});
 
@@ -190,7 +190,7 @@ async function init() {
 		type: 'blob'
 	});
 
-	await saveFile(zipBlob, `${user} ${repo} ${ref} ${dir}.zip`.replace(/\//, '-'));
+	await saveFile(zipBlob, `${user} ${repository} ${ref} ${dir}.zip`.replace(/\//, '-'));
 	updateStatus(`Downloaded ${downloaded} files! Done!`);
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "xo && npm run build"
   },
   "dependencies": {
-    "list-github-dir-content": "^1.1.1",
+    "list-github-dir-content": "^2.0.0",
     "save-file": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This basically consists of two parts:

- Use `list-github-dir-content` v2 to fetch details about files to download and adjust the whole codebase accordingly (e.g. we can no longer get the `user/repo` as a single string but have to split them up)
- Extract the functionality of a) fetching a file and b) turning it into a blob. Those need to be dynamically assigned dependening on whether the requested repo is public or private.

To do:
- Now that it returns the files' details, the `validateInput` function name may be subject to change (as it no longer only validates things but also provides information).
- Upload a file of more than 100 MB into a private repo and see what kind of error is produced and how it may be handled.

This resolves #7.