### PR TITLE
Import JSZip completely asynchronously 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 	<meta charset="UTF-8">
 	<title>Download GitHub directory</title>
 	<link rel="stylesheet" href="index.css">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js" integrity="sha256-PZ/OvdXxEW1u3nuTAUCSjd4lyaoJ3UJpv/X11x2Gi5c=" crossorigin="anonymous" defer></script>
 	<script src="index.js" defer></script>
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 </head>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* global JSZip */
 import saveFile from 'save-file';
 import listContent from 'list-github-dir-content';
 
@@ -80,7 +79,13 @@ async function fetchRepoInfo(repo) {
 	return response.json();
 }
 
+async function getZIP() {
+	const {default: JSZip} = await import('https://cdn.skypack.dev/jszip@^3.4.0');
+	return new JSZip();
+}
+
 async function init() {
+	const zip = getZIP();
 	let user;
 	let repository;
 	let ref;
@@ -153,7 +158,6 @@ async function init() {
 	};
 
 	let downloaded = 0;
-	const zip = new JSZip();
 
 	const download = async file => {
 		const blob = repoIsPrivate ?
@@ -163,7 +167,7 @@ async function init() {
 		downloaded++;
 		updateStatus(`Downloading (${downloaded}/${files.length}) files…`, file.path);
 
-		zip.file(file.path.replace(dir + '/', ''), blob, {
+		(await zip).file(file.path.replace(dir + '/', ''), blob, {
 			binary: true
 		});
 	};
@@ -190,7 +194,7 @@ async function init() {
 
 	updateStatus(`Zipping ${downloaded} files…`);
 
-	const zipBlob = await zip.generateAsync({
+	const zipBlob = await (await zip).generateAsync({
 		type: 'blob'
 	});
 


### PR DESCRIPTION
This should speed up the very first load because now it no longer waits for JSZip to finish loading **before** showing the initial UI, but it downloads JSZip together with the files.

Objections?

Let say that this resolves https://github.com/download-directory/download-directory.github.io/issues/1