### PR TITLE
Fix unable to download when file name contains #

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ async function init() {
 	const controller = new AbortController();
 
 	const fetchPublicFile = async file => {
-		const response = await fetch(`https://raw.githubusercontent.com/${user}/${repository}/${ref}/${file.path}`, {
+		const response = await fetch(`https://raw.githubusercontent.com/${user}/${repository}/${ref}/${encodeURIComponent(file.path)}`, {
 			signal: controller.signal,
 		});
 


### PR DESCRIPTION
fix #74 

Just simply add an `encodeURIComponent` should fix this issue.

Please let me know if there is anything I haven't considered.

Test it on https://tsuk1ko.github.io/download-directory.github.io/