### PR TITLE
Add support for custom zip filename

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,8 @@
 			<p>This tool will handle the download of all the files in a directory, in a single click, after you entered your token.</p>
 			<p>The download starts automatically when you visit pass the link to the GitHub directory as <code>url</code> parameter, like:</p>
 			<p><a href="/?url=https://github.com/mrdoob/three.js/tree/dev/build"><strong>download-directory.github.io</strong><code>?url=https://github.com/mrdoob/three.js/tree/dev/build</code></a></p>
+			<p>You can also specify download filename by adding <code>filename</code> parameter to the link, like:</p>
+			<p><a href="/?url=https://github.com/mrdoob/three.js/tree/dev/build&filename=three-js-build"><strong>download-directory.github.io</strong><code>?url=https://github.com/mrdoob/three.js/tree/dev/build&filename=three-js-build</code></a> to save the file as <strong>three-js-build.zip</strong>.</p>
 		</div>
 	</footer>
 	<pre class="status">Loading</pre>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 			<p>This tool will handle the download of all the files in a directory, in a single click, after you entered your token.</p>
 			<p>The download starts automatically when you visit pass the link to the GitHub directory as <code>url</code> parameter, like:</p>
 			<p><a href="/?url=https://github.com/mrdoob/three.js/tree/dev/build"><strong>download-directory.github.io</strong><code>?url=https://github.com/mrdoob/three.js/tree/dev/build</code></a></p>
-			<p>You can also specify download filename by adding <code>filename</code> parameter to the link, like:</p>
+			<p>You can also specify download filename by adding <code>filename</code> parameter, like:</p>
 			<p><a href="/?url=https://github.com/mrdoob/three.js/tree/dev/build&filename=three-js-build"><strong>download-directory.github.io</strong><code>?url=https://github.com/mrdoob/three.js/tree/dev/build&filename=three-js-build</code></a> to save the file as <strong>three-js-build.zip</strong>.</p>
 		</div>
 	</footer>

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ async function init() {
 	let repository;
 	let ref;
 	let dir;
-	let filename; 
+	let filename;
 
 	const input = document.querySelector('#token');
 	if (localStorage.token) {
@@ -143,7 +143,7 @@ async function init() {
 
 	try {
 		const query = new URLSearchParams(location.search);
-		filename = query.get('filename')
+		filename = query.get('filename');
 		const parsedUrl = new URL(query.get('url'));
 		[, user, repository, ref, dir] = urlParserRegex.exec(parsedUrl.pathname);
 
@@ -265,10 +265,10 @@ async function init() {
 	});
 
 	const zipFilename = filename
-		? filename.toLowerCase().endsWith(".zip")
+		? (filename.toLowerCase().endsWith('.zip')
 			? filename
-			: filename + ".zip"
-		: `${user} ${repository} ${ref} ${dir}.zip`.replace(/\//, "-");
+			: filename + '.zip')
+		: `${user} ${repository} ${ref} ${dir}.zip`.replace(/\//, '-');
 	await saveFile(zipBlob, zipFilename);
 	updateStatus(`Downloaded ${downloaded} files! Done!`);
 }

--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ async function init() {
 	let repository;
 	let ref;
 	let dir;
+	let filename; 
 
 	const input = document.querySelector('#token');
 	if (localStorage.token) {
@@ -142,6 +143,7 @@ async function init() {
 
 	try {
 		const query = new URLSearchParams(location.search);
+		filename = query.get('filename')
 		const parsedUrl = new URL(query.get('url'));
 		[, user, repository, ref, dir] = urlParserRegex.exec(parsedUrl.pathname);
 
@@ -262,7 +264,12 @@ async function init() {
 		type: 'blob',
 	});
 
-	await saveFile(zipBlob, `${user} ${repository} ${ref} ${dir}.zip`.replace(/\//, '-'));
+	const zipFilename = filename
+		? filename.toLowerCase().endsWith(".zip")
+			? filename
+			: filename + ".zip"
+		: `${user} ${repository} ${ref} ${dir}.zip`.replace(/\//, "-");
+	await saveFile(zipBlob, zipFilename);
 	updateStatus(`Downloaded ${downloaded} files! Done!`);
 }
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,10 @@ The download starts automatically when you visit pass the link to the GitHub dir
 
 [**download-directory.github.io**`?url=https://github.com/mrdoob/three.js/tree/dev/build`](https://download-directory.github.io/?url=https://github.com/mrdoob/three.js/tree/dev/build)
 
+You can also specify download filename by adding `filename` parameter, like:
+
+[**download-directory.github.io**`?url=https://github.com/mrdoob/three.js/tree/dev/build&filename=three-js-build`](/?url=https://github.com/mrdoob/three.js/tree/dev/build&filename=three-js-build) to save the file as **three-js-build.zip**.
+
 This is an alternative to the existing [GitZip](https://kinolien.github.io/gitzip/) and [DownGit](https://minhaskamal.github.io/DownGit/) but without the cruft.
 
 ## Related


### PR DESCRIPTION
Allow custom zip fileanme by adding `?filename=xxxxxxx` or `?filename=xxxxxxx.zip`.