### PR TITLE
Add partial support for full-repo download

### DIFF
--- a/index.css
+++ b/index.css
@@ -240,11 +240,12 @@ pre {
 	max-height: 100vh;
 	overflow: auto;
 }
-pre:first-line {
+pre div:first-child {
 	font-size: 20px;
+	white-space: pre-wrap;
 }
 
-.header {
+header {
 	background-color: rgba(100%, 100%, 100%, 13%);
 	padding: 3em;
 	text-align: center;

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
 	<meta name="google-site-verification" content="0AMR3lQZu5bzGS6wcqw1b9udtj7QCqRuDB-vQ52zylU"/>
 	<link rel="icon" href="favicon.ico"/>
 </head>
-<div class="header">
+<header>
 	No content is hosted on this website. This is a tool to download files from a user-provided GitHub repository URL.
-</div>
+</header>
 <main class="text-align-center">
 	<h1><a href="/">download-directory • github • io</a></h1>
 	<form>

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ async function init() {
 		filename = query.get('filename');
 		const parsedUrl = new URL(query.get('url'));
 		[, user, repository, type, ref, ...dir] = parsedUrl.pathname.split('/');
+		dir = dir.join('/');
 
 		if (googleDoesntLikeThis.test(parsedUrl)) {
 			updateStatus();
@@ -155,7 +156,7 @@ async function init() {
 			return;
 		}
 
-		if (type !== 'tree') {
+		if (type !== 'tree' || !ref) {
 			return updateStatus(`⚠ ${parsedUrl.pathname} is not a directory.`);
 		}
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ async function fetchRepoInfo(repo) {
 		case 403: {
 			// See https://developer.github.com/v3/#rate-limiting
 			if (response.headers.get('X-RateLimit-Remaining') === '0') {
-				updateStatus('⚠ Your token rate limit has been exceeded.', {token: localStorage.token});
+				updateStatus('⚠ Your token rate limit has been exceeded. Please wait or add a token', {token: localStorage.token});
 				throw new Error('Rate limit exceeded');
 			}
 
@@ -145,8 +145,13 @@ async function init() {
 
 	try {
 		const query = new URLSearchParams(location.search);
+		const url = query.get('url');
+		if (!url) {
+			return updateStatus();
+		}
+
 		filename = query.get('filename');
-		const parsedUrl = new URL(query.get('url'));
+		const parsedUrl = new URL(url);
 		[, user, repository, type, ref, ...dir] = parsedUrl.pathname.split('/');
 		dir = dir.join('/');
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,6 @@ import listContent from 'list-github-dir-content';
 import pMap from 'p-map';
 import pRetry from 'p-retry';
 
-// Matches '/<re/po>/tree/<ref>/<dir>'
-const urlParserRegex = /^[/]([^/]+)[/]([^/]+)[/]tree[/]([^/]+)[/](.*)/;
-
 async function maybeResponseLfs(response) {
 	const length = Number(response.headers.get('content-length'));
 	if (length > 128 && length < 140) {
@@ -43,7 +40,9 @@ async function repoListingSlashblanchSupport(ref, dir, repoListingConfig) {
 function updateStatus(status, ...extra) {
 	const element = document.querySelector('.status');
 	if (status) {
-		element.prepend(status + '\n');
+		const wrapper = document.createElement('div');
+		wrapper.textContent = status;
+		element.prepend(wrapper);
 	} else {
 		element.textContent = status || '';
 	}
@@ -130,6 +129,7 @@ async function init() {
 	let repository;
 	let ref;
 	let dir;
+	let type;
 	let filename;
 
 	const input = document.querySelector('#token');
@@ -147,7 +147,7 @@ async function init() {
 		const query = new URLSearchParams(location.search);
 		filename = query.get('filename');
 		const parsedUrl = new URL(query.get('url'));
-		[, user, repository, ref, dir] = urlParserRegex.exec(parsedUrl.pathname);
+		const [, user, repository, type, ref, ...dir] = parsedUrl.pathname.split('/');
 
 		if (googleDoesntLikeThis.test(parsedUrl)) {
 			updateStatus();
@@ -155,8 +155,33 @@ async function init() {
 			return;
 		}
 
+		if (type !== 'tree') {
+			return updateStatus(`⚠ ${parsedUrl.pathname} is not a directory.`);
+		}
+
+		updateStatus(`Repo: ${user}/${repository}\nDirectory: /${dir}`);
 		console.log('Source:', {user, repository, ref, dir});
-	} catch {
+
+		if (dir.length === 0) {
+			if (ref === 'master' || ref === 'main' || ref === 'HEAD') {
+				// This is most likely a branch
+				updateStatus('Downloading the entire repository directly from GitHub');
+				window.location.href = 'https://github.com/' + user + '/' + repository + '/archive/refs/heads/' + ref + '.zip';
+				return;
+			}
+
+			if (/^[0-9a-f]{40}$/.test(ref)) {
+				// This is most likely a commit
+				updateStatus('Downloading the entire repository directly from GitHub');
+				window.location.href = 'https://github.com/' + user + '/' + repository + '/archive/' + ref + '.zip';
+				return;
+			}
+
+			// Undeterminable without an extra API call
+			// https://github.com/download-directory/download-directory.github.io/issues/54#issuecomment-2198433286
+		}
+	} catch (error) {
+		console.error(error);
 		return updateStatus();
 	}
 
@@ -165,7 +190,7 @@ async function init() {
 		throw new Error('You are offline');
 	}
 
-	updateStatus(`Retrieving directory info \nRepo: ${user}/${repository}\nDirectory: /${dir}`);
+	updateStatus('Retrieving directory info');
 
 	const {private: repoIsPrivate} = await fetchRepoInfo(`${user}/${repository}`);
 

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ async function init() {
 		const query = new URLSearchParams(location.search);
 		filename = query.get('filename');
 		const parsedUrl = new URL(query.get('url'));
-		const [, user, repository, type, ref, ...dir] = parsedUrl.pathname.split('/');
+		[, user, repository, type, ref, ...dir] = parsedUrl.pathname.split('/');
 
 		if (googleDoesntLikeThis.test(parsedUrl)) {
 			updateStatus();


### PR DESCRIPTION
- Part of https://github.com/download-directory/download-directory.github.io/issues/54#issuecomment-2198433286

Support is only possible for known branch names and obvious commit hashes. Everything else will require an API call (and thus further work)

### Supported

```
https://github.com/fregante/webext-permission-toggle/tree/main
```
```
https://github.com/fregante/webext-permission-toggle/tree/e125b40129e53342bc6ac07a1afc29696da347a4
```

### Not supported

```
https://github.com/fregante/webext-permission-toggle
```
```
https://github.com/fregante/webext-permission-toggle/tree/some-branch
```
```
https://github.com/fregante/webext-permission-toggle/tree/v3.0.0
```